### PR TITLE
Add JavaScript package equivalent to Python cube-utils

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,9 @@ jobs:
     pypi-publish:
       name: upload release to PyPI
       runs-on: ubuntu-latest
+      environment:
+          name: Prod
+          url: https://pypi.org/p/cube-utils
       permissions:
         # This permission is needed for private repositories.
         contents: read
@@ -15,14 +18,26 @@ jobs:
       steps:
         - uses: actions/checkout@v4
   
-        - uses: pdm-project/setup-pdm@v4
-  
+        # Install PDM
+        - name: Install PDM
+          run: python -m pip install --upgrade pip pdm
+
+        # Install build dependencies
+        - name: Install build dependencies
+          run: pdm install --prod
+
+        # Build the package
+        - name: Build package
+          run: pdm build
+
         - name: Publish package distributions to PyPI
-          run: pdm publish
+          uses: pypa/gh-action-pypi-publish@release/v1
 
     npm-publish:
       name: upload release to npm
       runs-on: ubuntu-latest
+      environment:
+        name: Prod
       permissions:
         contents: read
         id-token: write

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,3 +19,32 @@ jobs:
   
         - name: Publish package distributions to PyPI
           run: pdm publish
+
+    npm-publish:
+      name: upload release to npm
+      runs-on: ubuntu-latest
+      permissions:
+        contents: read
+        id-token: write
+      steps:
+        - uses: actions/checkout@v4
+
+        - name: Set up Node.js
+          uses: actions/setup-node@v2
+          with:
+            node-version: '18'
+            registry-url: 'https://registry.npmjs.org'
+
+        - name: Install JavaScript dependencies
+          working-directory: ./cube-utils-js
+          run: npm install
+
+        - name: Run JavaScript tests
+          working-directory: ./cube-utils-js
+          run: npm test
+
+        - name: Publish package to npm
+          working-directory: ./cube-utils-js
+          run: npm publish --provenance --access public
+          env:
+            NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,9 +1,9 @@
-name: Python Tests
+name: Tests
 
 on: [push, pull_request]
 
 jobs:
-  test:
+  python-test:
     runs-on: ubuntu-latest
 
     strategy:
@@ -24,6 +24,26 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements.txt
 
-    - name: Run tests
+    - name: Run Python tests
       run: |
         python -m unittest discover -s tests
+
+  javascript-test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v2
+      with:
+        node-version: '18'
+
+    - name: Install JavaScript dependencies
+      working-directory: ./cube-utils-js
+      run: npm install
+
+    - name: Run JavaScript tests
+      working-directory: ./cube-utils-js
+      run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -171,4 +171,4 @@ cython_debug/
 .pypirc
 
 # build objects
-src/
+/src/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,35 +3,56 @@
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
 ## Project Overview
-Cube Utils is a Python library for parsing and extracting information from Cube.js query payloads. It provides utilities to extract cubes, members, filters, and URL parameters from query data structures.
+Cube Utils is a library for parsing and extracting information from Cube.js query payloads. It provides utilities to extract cubes, members, filters, and URL parameters from query data structures.
+
+This repository contains two implementations:
+- **Python package** (`cube_utils/`) - Original Python implementation
+- **JavaScript package** (`cube-utils-js/`) - JavaScript port with identical functionality
 
 ## Development Commands
 
 ### Running Tests
+
+**Python:**
 ```bash
 python -m unittest discover tests
 ```
 
+**JavaScript:**
+```bash
+cd cube-utils-js
+npm test
+```
+
 ### Building and Distribution
-This project uses PDM for dependency management:
+
+**Python** - Uses PDM for dependency management:
 ```bash
 pdm build
+```
+
+**JavaScript:**
+```bash
+cd cube-utils-js
+npm publish
 ```
 
 ## Code Architecture
 
 ### Core Modules
 
-**cube_utils/query_parser.py** - Main parsing functionality:
-- `extract_cubes()` - Extracts unique cube names from query payloads
-- `extract_members()` - Extracts all members (dimensions, measures, filters, segments, timeDimensions)
-- `extract_filters_members()` - Extracts only members from filters and segments
-- `extract_filters_members_with_values()` - Extracts filter members with their values as tuples
-- `extract_members_from_expression()` - Parses SQL expressions to find ${cube.member} patterns
-- `extract_members_from_filter()` - Handles nested boolean logic (AND/OR) in filters
+Both Python and JavaScript implementations provide identical functionality:
 
-**cube_utils/url_parser.py** - URL parameter extraction:
-- `extract_url_params()` - Extracts and URL-decodes query parameters from URLs
+**Query Parser** (`cube_utils/query_parser.py` & `cube-utils-js/src/query-parser.js`):
+- `extract_cubes()` / `extractCubes()` - Extracts unique cube names from query payloads
+- `extract_members()` / `extractMembers()` - Extracts all members (dimensions, measures, filters, segments, timeDimensions)
+- `extract_filters_members()` / `extractFiltersMembers()` - Extracts only members from filters and segments
+- `extract_filters_members_with_values()` / `extractFiltersMembersWithValues()` - Extracts filter members with their values as tuples
+- `extract_members_from_expression()` / `extractMembersFromExpression()` - Parses SQL expressions to find ${cube.member} patterns
+- `extract_members_from_filter()` / `extractMembersFromFilter()` - Handles nested boolean logic (AND/OR) in filters
+
+**URL Parser** (`cube_utils/url_parser.py` & `cube-utils-js/src/url-parser.js`):
+- `extract_url_params()` / `extractUrlParams()` - Extracts and URL-decodes query parameters from URLs
 
 ### Key Data Structures
 
@@ -55,6 +76,20 @@ Filters support nested boolean logic with `and` and `or` operators. The parser r
 The library can parse SQL expressions to extract member references in the format `${cube.member}` and extract member-value pairs from equality conditions.
 
 ## Testing Structure
+
+**Python Tests:**
 - `tests/test_query_parser.py` - Comprehensive tests for all query parsing functions
 - `tests/test_url_parser.py` - Tests for URL parameter extraction
-- Tests cover edge cases including empty payloads, complex boolean logic, and pushdown queries
+- `tests/test_cube_package.py` - Tests for Cube.js framework integration (Python only)
+
+**JavaScript Tests:**
+- `cube-utils-js/test/query-parser.test.js` - Equivalent tests for query parsing functions
+- `cube-utils-js/test/url-parser.test.js` - Equivalent tests for URL parameter extraction
+
+Tests cover edge cases including empty payloads, complex boolean logic, and pushdown queries. Both implementations pass identical test suites to ensure functional equivalence.
+
+## GitHub Actions
+
+The repository includes automated workflows:
+- **Tests workflow** - Runs both Python and JavaScript tests on every push/PR
+- **Publish workflow** - Publishes to both PyPI (Python) and npm (JavaScript) on GitHub releases

--- a/cube-utils-js/README.md
+++ b/cube-utils-js/README.md
@@ -7,7 +7,7 @@ This is a JavaScript port of the Python `cube-utils` library, providing the same
 ## Installation
 
 ```bash
-npm install cube-utils-js
+npm install 
 ```
 
 ## Features
@@ -27,7 +27,7 @@ import {
   extractMembers,
   extractFiltersMembers,
   extractFiltersMembersWithValues
-} from 'cube-utils-js';
+} from '';
 
 const payload = {
   dimensions: ['sales.city', 'sales.country'],
@@ -65,7 +65,7 @@ const membersWithValues = extractFiltersMembersWithValues(payload);
 ### URL Parser
 
 ```javascript
-import { extractUrlParams } from 'cube-utils-js';
+import { extractUrlParams } from '';
 
 const url = '/cubejs-api/v1/load?query=%7B%22measures%22%3A%5B%22sales.count%22%5D%7D&foo=bar';
 const params = extractUrlParams(url);

--- a/cube-utils-js/README.md
+++ b/cube-utils-js/README.md
@@ -1,0 +1,116 @@
+# Cube Utils JS
+
+JavaScript utilities for parsing and extracting information from Cube.js query payloads.
+
+This is a JavaScript port of the Python `cube-utils` library, providing the same core parsing functionality for working with Cube.js query data structures.
+
+## Installation
+
+```bash
+npm install cube-utils-js
+```
+
+## Features
+
+- **Query parsing** - Extract cubes, members, filters from Cube.js query data structures
+- **URL parameter extraction** - Parse and decode query parameters from URLs
+- **SQL expression parsing** - Find member references in `${cube.member}` format
+- **Boolean logic handling** - Process nested AND/OR filter conditions
+
+## Usage
+
+### Query Parser
+
+```javascript
+import { 
+  extractCubes,
+  extractMembers,
+  extractFiltersMembers,
+  extractFiltersMembersWithValues
+} from 'cube-utils-js';
+
+const payload = {
+  dimensions: ['sales.city', 'sales.country'],
+  measures: ['sales.count'],
+  filters: [
+    { values: ['US'], member: 'sales.country', operator: 'equals' }
+  ],
+  segments: ['sales.active_users'],
+  timeDimensions: [
+    {
+      dimension: 'sales.date',
+      dateRange: ['2021-01-01', '2021-12-31'],
+      granularity: 'month'
+    }
+  ]
+};
+
+// Extract unique cube names
+const cubes = extractCubes(payload);
+// Returns: ['sales']
+
+// Extract all members
+const members = extractMembers(payload);
+// Returns: ['sales.city', 'sales.country', 'sales.count', 'sales.date', 'sales.active_users']
+
+// Extract only filter and segment members
+const filterMembers = extractFiltersMembers(payload);
+// Returns: ['sales.country', 'sales.active_users']
+
+// Extract filter members with their values
+const membersWithValues = extractFiltersMembersWithValues(payload);
+// Returns: [['sales.country', ['US']], ['sales.active_users', null]]
+```
+
+### URL Parser
+
+```javascript
+import { extractUrlParams } from 'cube-utils-js';
+
+const url = '/cubejs-api/v1/load?query=%7B%22measures%22%3A%5B%22sales.count%22%5D%7D&foo=bar';
+const params = extractUrlParams(url);
+// Returns: { query: '{"measures":["sales.count"]}', foo: 'bar' }
+```
+
+## API Reference
+
+### Query Parser Functions
+
+#### `extractCubes(payload)`
+Extracts unique cube names from a query payload.
+- **Parameters**: `payload` (Object) - The Cube.js query payload
+- **Returns**: Array of unique cube names
+
+#### `extractMembers(payload, queryKeys?)`
+Extracts unique members from a query payload.
+- **Parameters**: 
+  - `payload` (Object) - The Cube.js query payload
+  - `queryKeys` (Array, optional) - Keys to extract from (defaults to all query types)
+- **Returns**: Array of unique member names
+
+#### `extractFiltersMembers(payload)`
+Extracts members from filters and segments only.
+- **Parameters**: `payload` (Object) - The Cube.js query payload
+- **Returns**: Array of filter/segment member names
+
+#### `extractFiltersMembersWithValues(payload)`
+Extracts filter members along with their values.
+- **Parameters**: `payload` (Object) - The Cube.js query payload
+- **Returns**: Array of [member, values] tuples
+
+### URL Parser Functions
+
+#### `extractUrlParams(url)`
+Extracts and URL-decodes query parameters from a URL.
+- **Parameters**: `url` (string) - The URL to parse
+- **Returns**: Object with parameter key-value pairs
+
+## Testing
+
+```bash
+npm test
+```
+
+## License
+
+MIT

--- a/cube-utils-js/package.json
+++ b/cube-utils-js/package.json
@@ -18,7 +18,5 @@
   ],
   "author": "",
   "license": "MIT",
-  "devDependencies": {
-    "node:test": "*"
-  }
+  "devDependencies": {}
 }

--- a/cube-utils-js/package.json
+++ b/cube-utils-js/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "cube-utils-js",
+  "version": "0.1.0",
+  "description": "JavaScript utilities for parsing and extracting information from Cube.js query payloads",
+  "main": "src/index.js",
+  "type": "module",
+  "scripts": {
+    "test": "node --test",
+    "test:watch": "node --test --watch"
+  },
+  "keywords": [
+    "cube",
+    "cubejs",
+    "query",
+    "parser",
+    "analytics",
+    "url-parser"
+  ],
+  "author": "",
+  "license": "MIT",
+  "devDependencies": {
+    "node:test": "*"
+  }
+}

--- a/cube-utils-js/package.json
+++ b/cube-utils-js/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "cube-utils-js",
+  "name": "cube-utils",
   "version": "0.1.0",
   "description": "JavaScript utilities for parsing and extracting information from Cube.js query payloads",
   "main": "src/index.js",

--- a/cube-utils-js/src/index.js
+++ b/cube-utils-js/src/index.js
@@ -1,0 +1,2 @@
+export * from './query-parser.js';
+export * from './url-parser.js';

--- a/cube-utils-js/src/query-parser.js
+++ b/cube-utils-js/src/query-parser.js
@@ -1,0 +1,307 @@
+/**
+ * Check if a member is a pushdown member.
+ * A pushdown member is an object with 'cubeName' and 'expressionName' properties.
+ * @param {any} member - The member to check.
+ * @returns {boolean} True if the member is a pushdown member, false otherwise.
+ */
+function isPushdownMember(member) {
+    return (
+        typeof member === 'object' &&
+        member !== null &&
+        'cubeName' in member &&
+        'expressionName' in member
+    );
+}
+
+/**
+ * Extracts unique cubes from the given query payload.
+ * @param {Object} payload - The query payload containing dimensions, measures, filters, segments, and time dimensions.
+ * @returns {string[]} A list of unique cube names.
+ */
+function extractCubes(payload) {
+    const cubes = new Set();
+    const members = extractMembers(payload);
+    for (const member of members) {
+        const cube = member.split('.')[0];
+        cubes.add(cube);
+    }
+    return Array.from(cubes);
+}
+
+/**
+ * Extracts unique members from the given query payload.
+ * @param {Object} payload - The query payload containing dimensions, measures, filters, segments, and time dimensions.
+ * @param {string[]} queryKeys - The keys to extract from (defaults to all query types).
+ * @returns {string[]} A list of unique members in the format 'cubeName.expressionName'.
+ */
+function extractMembers(
+    payload,
+    queryKeys = ['dimensions', 'measures', 'filters', 'segments', 'timeDimensions']
+) {
+    const members = new Set();
+
+    for (const key of queryKeys) {
+        if (key in payload) {
+            for (const item of payload[key]) {
+                if (isPushdownMember(item)) {
+                    // Try to extract from expression or definition
+                    let exprMembers = new Set();
+                    if ('expression' in item && Array.isArray(item.expression)) {
+                        for (const expr of item.expression) {
+                            if (typeof expr === 'string') {
+                                const member = extractMembersFromExpression(expr);
+                                if (member.length > 0) {
+                                    member.forEach(m => exprMembers.add(m));
+                                }
+                            }
+                        }
+                    }
+                    if (
+                        exprMembers.size === 0 &&
+                        'definition' in item &&
+                        typeof item.definition === 'string'
+                    ) {
+                        const member = extractMembersFromExpression(item.definition);
+                        if (member.length > 0) {
+                            member.forEach(m => exprMembers.add(m));
+                        }
+                    }
+                    if (exprMembers.size > 0) {
+                        exprMembers.forEach(m => members.add(m));
+                    } else {
+                        members.add(`${item.cubeName}.${item.expressionName}`);
+                    }
+                } else if (key === 'filters') {
+                    const filterMembers = extractMembersFromFilter(item);
+                    filterMembers.forEach(m => members.add(m));
+                } else if (
+                    key === 'timeDimensions' &&
+                    typeof item === 'object' &&
+                    item !== null &&
+                    'dimension' in item
+                ) {
+                    members.add(item.dimension);
+                } else {
+                    members.add(item);
+                }
+            }
+        }
+    }
+
+    return Array.from(members);
+}
+
+/**
+ * Extracts all members in the format ${cube.member} from a string expression.
+ * @param {string} expr - The expression to extract members from.
+ * @returns {string[]} Array of member names.
+ */
+function extractMembersFromExpression(expr) {
+    const matches = expr.match(/\$\{([a-zA-Z0-9_]+\.[a-zA-Z0-9_]+)\}/g);
+    if (!matches) return [];
+    return matches.map(match => match.slice(2, -1)); // Remove ${ and }
+}
+
+/**
+ * Extracts member-value pairs from SQL expressions.
+ * @param {string} sql - The SQL expression to parse.
+ * @returns {Array<[string, string]>} Array of [member, value] pairs.
+ */
+function extractMemberValueFromSql(sql) {
+    const pattern = /\$\{([a-zA-Z0-9_]+\.[a-zA-Z0-9_]+)\}\s*=\s*([^)\s]+)/g;
+    const matches = [];
+    let match;
+    while ((match = pattern.exec(sql)) !== null) {
+        matches.push([match[1], match[2]]);
+    }
+    return matches;
+}
+
+/**
+ * Extracts members from a filter item, handling boolean logic (AND/OR) recursively.
+ * @param {Object} filterItem - The filter item to extract members from.
+ * @returns {Set<string>} A set of unique members extracted from the filter item.
+ */
+function extractMembersFromFilter(filterItem) {
+    const members = new Set();
+
+    // Handle direct member filters
+    if ('member' in filterItem) {
+        members.add(filterItem.member);
+    }
+
+    // Handle AND conditions
+    if ('and' in filterItem) {
+        for (const condition of filterItem.and) {
+            const conditionMembers = extractMembersFromFilter(condition);
+            conditionMembers.forEach(m => members.add(m));
+        }
+    }
+
+    // Handle OR conditions
+    if ('or' in filterItem) {
+        for (const condition of filterItem.or) {
+            const conditionMembers = extractMembersFromFilter(condition);
+            conditionMembers.forEach(m => members.add(m));
+        }
+    }
+
+    return members;
+}
+
+/**
+ * Extracts the members from filters from the given query payload.
+ * @param {Object} payload - The query payload containing dimensions, measures, filters, segments, and time dimensions.
+ * @returns {string[]} A list of members.
+ */
+function extractFiltersMembers(payload) {
+    const queryKeys = ['filters', 'segments'];
+    return extractMembers(payload, queryKeys);
+}
+
+/**
+ * Extracts (member, value) tuples from filters and segments in the given query payload.
+ * For filters, value is the 'values' field if present, otherwise null.
+ * For segments, value is always null unless a value can be extracted from a pushdown SQL expression.
+ * Handles nested boolean logic in filters.
+ * Ensures unique members and unique values per member.
+ * @param {Object} payload - The query payload.
+ * @returns {Array<[string, any]>} Array of [member, values] tuples.
+ */
+function extractFiltersMembersWithValues(payload) {
+    const result = new Map();
+
+    function extractFromFilter(filterItem) {
+        if ('member' in filterItem) {
+            const value = filterItem.values;
+            if (value !== undefined && value !== null) {
+                if (!result.has(filterItem.member)) {
+                    result.set(filterItem.member, new Set());
+                }
+                if (Array.isArray(value)) {
+                    value.forEach(v => result.get(filterItem.member).add(v));
+                } else {
+                    result.get(filterItem.member).add(value);
+                }
+            } else {
+                if (!result.has(filterItem.member)) {
+                    result.set(filterItem.member, new Set());
+                }
+            }
+        }
+        if ('and' in filterItem) {
+            for (const cond of filterItem.and) {
+                extractFromFilter(cond);
+            }
+        }
+        if ('or' in filterItem) {
+            for (const cond of filterItem.or) {
+                extractFromFilter(cond);
+            }
+        }
+    }
+
+    if ('filters' in payload) {
+        for (const filterItem of payload.filters) {
+            extractFromFilter(filterItem);
+        }
+    }
+
+    if ('segments' in payload) {
+        for (const seg of payload.segments) {
+            if (typeof seg === 'object' && seg !== null && isPushdownMember(seg)) {
+                const exprMembers = new Map();
+                const sqls = [];
+                if ('expression' in seg && Array.isArray(seg.expression)) {
+                    for (const expr of seg.expression) {
+                        if (typeof expr === 'string') {
+                            sqls.push(expr);
+                        }
+                    }
+                }
+                if ('definition' in seg && typeof seg.definition === 'string') {
+                    sqls.push(seg.definition);
+                }
+                let found = false;
+                for (const sql of sqls) {
+                    for (const [member, value] of extractMemberValueFromSql(sql)) {
+                        found = true;
+                        // Remove quotes from value if present
+                        let cleanValue = value;
+                        if (cleanValue.startsWith('`') && cleanValue.endsWith('`')) {
+                            cleanValue = cleanValue.slice(1, -1);
+                        }
+                        try {
+                            cleanValue = parseInt(cleanValue, 10);
+                            if (isNaN(cleanValue)) {
+                                cleanValue = value;
+                            }
+                        } catch {
+                            // Keep original value if parsing fails
+                        }
+                        if (!exprMembers.has(member)) {
+                            exprMembers.set(member, new Set());
+                        }
+                        exprMembers.get(member).add(cleanValue);
+                    }
+                }
+                if (found) {
+                    for (const [m, vals] of exprMembers) {
+                        if (!result.has(m)) {
+                            result.set(m, new Set());
+                        }
+                        vals.forEach(v => result.get(m).add(v));
+                    }
+                } else {
+                    // fallback to just extracting members
+                    for (const sql of sqls) {
+                        for (const member of extractMembersFromExpression(sql)) {
+                            if (!result.has(member)) {
+                                result.set(member, new Set());
+                            }
+                        }
+                    }
+                }
+                if (sqls.length === 0) {
+                    const memberName = `${seg.cubeName}.${seg.expressionName}`;
+                    if (!result.has(memberName)) {
+                        result.set(memberName, new Set());
+                    }
+                }
+            } else if (typeof seg === 'object' && seg !== null) {
+                const name = seg.name || seg.expressionName;
+                if (name) {
+                    if (!result.has(name)) {
+                        result.set(name, new Set());
+                    }
+                }
+            } else {
+                if (!result.has(seg)) {
+                    result.set(seg, new Set());
+                }
+            }
+        }
+    }
+
+    // Convert sets to sorted arrays or null if empty
+    const output = [];
+    for (const [k, v] of result) {
+        if (v.size > 0) {
+            output.push([k, Array.from(v).sort()]);
+        } else {
+            output.push([k, null]);
+        }
+    }
+    return output;
+}
+
+export {
+    isPushdownMember,
+    extractCubes,
+    extractMembers,
+    extractMembersFromExpression,
+    extractMemberValueFromSql,
+    extractMembersFromFilter,
+    extractFiltersMembers,
+    extractFiltersMembersWithValues
+};

--- a/cube-utils-js/src/url-parser.js
+++ b/cube-utils-js/src/url-parser.js
@@ -1,0 +1,38 @@
+/**
+ * Extract query parameters from a URL using built-in URL APIs.
+ * 
+ * @param {string} url - The input URL string.
+ * @returns {Object} A dictionary of query parameters with URL-decoded values.
+ */
+function extractUrlParams(url) {
+    try {
+        // Handle relative URLs by using a dummy base
+        const urlObj = new URL(url, 'https://example.com');
+        const params = {};
+        
+        for (const [key, value] of urlObj.searchParams) {
+            // Skip empty values
+            if (value === '') {
+                continue;
+            }
+            
+            if (params[key]) {
+                // If key already exists, convert to array or append to existing array
+                if (Array.isArray(params[key])) {
+                    params[key].push(value);
+                } else {
+                    params[key] = [params[key], value];
+                }
+            } else {
+                params[key] = value;
+            }
+        }
+        
+        return params;
+    } catch (error) {
+        // If URL parsing fails, return empty object
+        return {};
+    }
+}
+
+export { extractUrlParams };

--- a/cube-utils-js/test/query-parser.test.js
+++ b/cube-utils-js/test/query-parser.test.js
@@ -1,0 +1,578 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import {
+    extractCubes,
+    extractMembers,
+    extractFiltersMembers,
+    extractFiltersMembersWithValues
+} from '../src/query-parser.js';
+
+// Test ExtractCubes
+test('extractCubes with all fields', () => {
+    const payload = {
+        dimensions: ['test_a.city', 'test_a.country', 'test_a.state'],
+        measures: ['test_b.count'],
+        filters: [
+            { values: ['US'], member: 'test_a.country', operator: 'equals' }
+        ],
+        segments: ['test_d.us_segment'],
+        timeDimensions: [
+            {
+                dimension: 'test_c.time',
+                dateRange: ['2021-01-01', '2021-12-31'],
+                granularity: 'month'
+            }
+        ]
+    };
+    const expectedCubes = ['test_a', 'test_b', 'test_c', 'test_d'];
+    assert.deepStrictEqual(extractCubes(payload).sort(), expectedCubes.sort());
+});
+
+test('extractCubes complex boolean logic', () => {
+    const payload = {
+        segments: [],
+        filters: [
+            {
+                or: [
+                    {
+                        and: [
+                            {
+                                values: ['Corpus Christi'],
+                                member: 'test_a.city',
+                                operator: 'equals'
+                            },
+                            {
+                                member: 'test_b.age_bucket',
+                                operator: 'equals',
+                                values: ['Senior adult']
+                            }
+                        ]
+                    },
+                    {
+                        member: 'test_c.city',
+                        operator: 'equals',
+                        values: ['Sacramento']
+                    }
+                ]
+            },
+            { or: [{ member: 'test_d.city', operator: 'set' }] }
+        ]
+    };
+    const expectedCubes = ['test_a', 'test_b', 'test_c', 'test_d'];
+    assert.deepStrictEqual(extractCubes(payload).sort(), expectedCubes.sort());
+});
+
+test('extractCubes pushed down query with measures', () => {
+    const payload = {
+        segments: [],
+        timezone: 'UTC',
+        measures: [
+            {
+                cubeName: 'test_a',
+                name: 'foo',
+                expressionName: 'foo',
+                definition: '{"cubeName":"test_a","alias":"foo","expr":{"type":"SqlFunction","cubeParams":["test_a"],"sql":"MIN(${test_a.active_from_at})"},"groupingSet":null}',
+                expression: [
+                    'test_a',
+                    'return `MIN(${test_a.active_from_at})`'
+                ],
+                groupingSet: null
+            },
+            {
+                definition: '{"cubeName":"test_b","alias":"bar","expr":{"type":"SqlFunction","cubeParams":["test_b"],"sql":"MAX(${test_b.active_from_at})"},"groupingSet":null}',
+                groupingSet: null,
+                expression: [
+                    'test_b',
+                    'return `MAX(${test_b.active_from_at})`'
+                ],
+                name: 'bar',
+                cubeName: 'test_b',
+                expressionName: 'bar'
+            },
+            {
+                name: 'count_uint8_1__',
+                expressionName: 'count_uint8_1__',
+                groupingSet: null,
+                cubeName: 'test_c',
+                expression: [
+                    'test_c',
+                    'return `${test_c.count}`'
+                ],
+                definition: '{"cubeName":"test_c","alias":"count_uint8_1__","expr":{"type":"SqlFunction","cubeParams":["test_c"],"sql":"${test_c.count}"},"groupingSet":null}'
+            }
+        ],
+        filters: [],
+        timeDimensions: [],
+        order: [],
+        dimensions: [],
+        subqueryJoins: [],
+        limit: null
+    };
+    const expectedCubes = ['test_a', 'test_b', 'test_c'];
+    assert.deepStrictEqual(extractCubes(payload).sort(), expectedCubes.sort());
+});
+
+test('extractCubes with dimensions only', () => {
+    const payload = { dimensions: ['test_a.city', 'test_a.country', 'test_a.state'] };
+    const expectedCubes = ['test_a'];
+    assert.deepStrictEqual(extractCubes(payload).sort(), expectedCubes.sort());
+});
+
+test('extractCubes with measures only', () => {
+    const payload = { measures: ['test_b.count'] };
+    const expectedCubes = ['test_b'];
+    assert.deepStrictEqual(extractCubes(payload).sort(), expectedCubes.sort());
+});
+
+test('extractCubes with filters only', () => {
+    const payload = {
+        filters: [
+            { values: ['US'], member: 'test_a.country', operator: 'equals' }
+        ]
+    };
+    const expectedCubes = ['test_a'];
+    assert.deepStrictEqual(extractCubes(payload).sort(), expectedCubes.sort());
+});
+
+test('extractCubes with segments only', () => {
+    const payload = { segments: ['test_a.us_segment'] };
+    const expectedCubes = ['test_a'];
+    assert.deepStrictEqual(extractCubes(payload).sort(), expectedCubes.sort());
+});
+
+test('extractCubes with timeDimensions only', () => {
+    const payload = {
+        timeDimensions: [
+            {
+                dimension: 'test_c.time',
+                dateRange: ['2021-01-01', '2021-12-31'],
+                granularity: 'month'
+            }
+        ]
+    };
+    const expectedCubes = ['test_c'];
+    assert.deepStrictEqual(extractCubes(payload).sort(), expectedCubes.sort());
+});
+
+test('extractCubes with empty payload', () => {
+    const payload = {};
+    const expectedCubes = [];
+    assert.deepStrictEqual(extractCubes(payload), expectedCubes);
+});
+
+test('extractCubes with invalid keywords', () => {
+    const payload = { invalid: ['test_a.city', 'test_a.country', 'test_a.state'] };
+    const expectedCubes = [];
+    assert.deepStrictEqual(extractCubes(payload), expectedCubes);
+});
+
+// Test ExtractMembers
+test('extractMembers with all fields', () => {
+    const payload = {
+        dimensions: ['test_a.city', 'test_a.country', 'test_a.state'],
+        measures: ['test_b.count'],
+        filters: [
+            { values: ['US'], member: 'test_a.country', operator: 'equals' }
+        ],
+        segments: ['test_d.us_segment'],
+        timeDimensions: [
+            {
+                dimension: 'test_c.time',
+                dateRange: ['2021-01-01', '2021-12-31'],
+                granularity: 'month'
+            }
+        ]
+    };
+    const expectedMembers = [
+        'test_a.city',
+        'test_a.country',
+        'test_a.state',
+        'test_b.count',
+        'test_c.time',
+        'test_d.us_segment'
+    ];
+    assert.deepStrictEqual(extractMembers(payload).sort(), expectedMembers.sort());
+});
+
+test('extractMembers complex boolean logic', () => {
+    const payload = {
+        segments: [],
+        filters: [
+            {
+                or: [
+                    {
+                        and: [
+                            {
+                                values: ['Corpus Christi'],
+                                member: 'test_a.city',
+                                operator: 'equals'
+                            },
+                            {
+                                member: 'test_b.age_bucket',
+                                operator: 'equals',
+                                values: ['Senior adult']
+                            }
+                        ]
+                    },
+                    {
+                        member: 'test_c.city',
+                        operator: 'equals',
+                        values: ['Sacramento']
+                    }
+                ]
+            },
+            { or: [{ member: 'test_d.city', operator: 'set' }] }
+        ]
+    };
+    const expectedMembers = [
+        'test_a.city',
+        'test_b.age_bucket',
+        'test_c.city',
+        'test_d.city'
+    ];
+    assert.deepStrictEqual(extractMembers(payload).sort(), expectedMembers.sort());
+});
+
+test('extractMembers with dimensions only', () => {
+    const payload = { dimensions: ['test_a.city', 'test_a.country', 'test_a.state'] };
+    const expectedMembers = ['test_a.city', 'test_a.country', 'test_a.state'];
+    assert.deepStrictEqual(extractMembers(payload).sort(), expectedMembers.sort());
+});
+
+test('extractMembers with measures only', () => {
+    const payload = { measures: ['test_b.count'] };
+    const expectedMembers = ['test_b.count'];
+    assert.deepStrictEqual(extractMembers(payload).sort(), expectedMembers.sort());
+});
+
+test('extractMembers with filters only', () => {
+    const payload = {
+        filters: [
+            { values: ['US'], member: 'test_a.country', operator: 'equals' }
+        ]
+    };
+    const expectedMembers = ['test_a.country'];
+    assert.deepStrictEqual(extractMembers(payload).sort(), expectedMembers.sort());
+});
+
+test('extractMembers with segments only', () => {
+    const payload = { segments: ['test_a.us_segment'] };
+    const expectedMembers = ['test_a.us_segment'];
+    assert.deepStrictEqual(extractMembers(payload).sort(), expectedMembers.sort());
+});
+
+test('extractMembers with timeDimensions only', () => {
+    const payload = {
+        timeDimensions: [
+            {
+                dimension: 'test_c.time',
+                dateRange: ['2021-01-01', '2021-12-31'],
+                granularity: 'month'
+            }
+        ]
+    };
+    const expectedMembers = ['test_c.time'];
+    assert.deepStrictEqual(extractMembers(payload).sort(), expectedMembers.sort());
+});
+
+test('extractMembers with empty payload', () => {
+    const payload = {};
+    const expectedMembers = [];
+    assert.deepStrictEqual(extractMembers(payload), expectedMembers);
+});
+
+test('extractMembers with invalid keywords', () => {
+    const payload = { invalid: ['test_a.city', 'test_a.country', 'test_a.state'] };
+    const expectedMembers = [];
+    assert.deepStrictEqual(extractMembers(payload), expectedMembers);
+});
+
+// Test ExtractFiltersMembers
+test('extractFiltersMembers with all fields', () => {
+    const payload = {
+        dimensions: ['test_a.city', 'test_a.country', 'test_a.state'],
+        measures: ['test_b.count'],
+        filters: [
+            { values: ['US'], member: 'test_a.country', operator: 'equals' }
+        ],
+        segments: ['test_d.us_segment'],
+        timeDimensions: [
+            {
+                dimension: 'test_c.time',
+                dateRange: ['2021-01-01', '2021-12-31'],
+                granularity: 'month'
+            }
+        ]
+    };
+    const expectedMembers = ['test_a.country', 'test_d.us_segment'];
+    assert.deepStrictEqual(extractFiltersMembers(payload).sort(), expectedMembers.sort());
+});
+
+test('extractFiltersMembers complex boolean logic', () => {
+    const payload = {
+        segments: [],
+        filters: [
+            {
+                or: [
+                    {
+                        and: [
+                            {
+                                values: ['Corpus Christi'],
+                                member: 'test_a.city',
+                                operator: 'equals'
+                            },
+                            {
+                                member: 'test_b.age_bucket',
+                                operator: 'equals',
+                                values: ['Senior adult']
+                            }
+                        ]
+                    },
+                    {
+                        member: 'test_c.city',
+                        operator: 'equals',
+                        values: ['Sacramento']
+                    }
+                ]
+            },
+            { or: [{ member: 'test_d.city', operator: 'set' }] }
+        ]
+    };
+    const expectedMembers = [
+        'test_a.city',
+        'test_b.age_bucket',
+        'test_c.city',
+        'test_d.city'
+    ];
+    assert.deepStrictEqual(extractFiltersMembers(payload).sort(), expectedMembers.sort());
+});
+
+test('extractFiltersMembers with dimensions only', () => {
+    const payload = { dimensions: ['test_a.city', 'test_a.country', 'test_a.state'] };
+    const expectedMembers = [];
+    assert.deepStrictEqual(extractFiltersMembers(payload).sort(), expectedMembers.sort());
+});
+
+test('extractFiltersMembers with measures only', () => {
+    const payload = { measures: ['test_b.count'] };
+    const expectedMembers = [];
+    assert.deepStrictEqual(extractFiltersMembers(payload).sort(), expectedMembers.sort());
+});
+
+test('extractFiltersMembers with filters only', () => {
+    const payload = {
+        filters: [
+            { values: ['US'], member: 'test_a.country', operator: 'equals' }
+        ]
+    };
+    const expectedMembers = ['test_a.country'];
+    assert.deepStrictEqual(extractFiltersMembers(payload).sort(), expectedMembers.sort());
+});
+
+test('extractFiltersMembers with segments only', () => {
+    const payload = { segments: ['test_a.us_segment'] };
+    const expectedMembers = ['test_a.us_segment'];
+    assert.deepStrictEqual(extractFiltersMembers(payload).sort(), expectedMembers.sort());
+});
+
+test('extractFiltersMembers with timeDimensions only', () => {
+    const payload = {
+        timeDimensions: [
+            {
+                dimension: 'test_c.time',
+                dateRange: ['2021-01-01', '2021-12-31'],
+                granularity: 'month'
+            }
+        ]
+    };
+    const expectedMembers = [];
+    assert.deepStrictEqual(extractFiltersMembers(payload).sort(), expectedMembers.sort());
+});
+
+test('extractFiltersMembers with empty payload', () => {
+    const payload = {};
+    const expectedMembers = [];
+    assert.deepStrictEqual(extractFiltersMembers(payload), expectedMembers);
+});
+
+test('extractFiltersMembers with invalid keywords', () => {
+    const payload = { invalid: ['test_a.city', 'test_a.country', 'test_a.state'] };
+    const expectedMembers = [];
+    assert.deepStrictEqual(extractFiltersMembers(payload), expectedMembers);
+});
+
+test('extractFiltersMembers pushdown filters', () => {
+    const payload = {
+        timezone: 'UTC',
+        timeDimensions: [],
+        filters: [],
+        measures: [
+            {
+                name: 'count_case_when_',
+                expression: [
+                    'internet_sales',
+                    'return `COUNT(CASE WHEN (${internet_sales.salesterritorykey} = 1) THEN 1 END)`'
+                ],
+                definition: '{"cubeName":"internet_sales","alias":"count_case_when_","expr":{"type":"SqlFunction","cubeParams":["internet_sales"],"sql":"COUNT(CASE WHEN (${internet_sales.salesterritorykey} = 1) THEN 1 END)"},"groupingSet":null}',
+                cubeName: 'internet_sales',
+                groupingSet: null,
+                expressionName: 'count_case_when_'
+            }
+        ],
+        order: [],
+        limit: null,
+        segments: [
+            {
+                expression: [
+                    'internet_sales',
+                    'return `CASE WHEN ((${internet_sales.salesterritorykey} = 1) OR (${internet_sales.salesterritorykey} = 9)) THEN TRUE END`'
+                ],
+                groupingSet: null,
+                definition: '{"cubeName":"internet_sales","alias":"case_when_s_sale","expr":{"type":"SqlFunction","cubeParams":["internet_sales"],"sql":"CASE WHEN ((${internet_sales.salesterritorykey} = 1) OR (${internet_sales.salesterritorykey} = 9)) THEN TRUE END"},"groupingSet":null}',
+                cubeName: 'internet_sales',
+                name: 'case_when_s_sale',
+                expressionName: 'case_when_s_sale'
+            }
+        ],
+        dimensions: [
+            {
+                cubeName: 'internet_sales',
+                expressionName: 'productkey',
+                groupingSet: null,
+                name: 'productkey',
+                definition: '{"cubeName":"internet_sales","alias":"productkey","expr":{"type":"SqlFunction","cubeParams":["internet_sales"],"sql":"${internet_sales.productkey}"},"groupingSet":null}',
+                expression: [
+                    'internet_sales',
+                    'return `${internet_sales.productkey}`'
+                ]
+            }
+        ],
+        subqueryJoins: []
+    };
+    const expectedMembers = ['internet_sales.salesterritorykey'];
+    assert.deepStrictEqual(extractFiltersMembers(payload).sort(), expectedMembers.sort());
+});
+
+// Test ExtractFiltersMembersWithValues
+test('extractFiltersMembersWithValues with all fields', () => {
+    const payload = {
+        dimensions: ['test_a.city', 'test_a.country', 'test_a.state'],
+        measures: ['test_b.count'],
+        filters: [
+            { values: ['US'], member: 'test_a.country', operator: 'equals' }
+        ],
+        segments: ['test_d.us_segment'],
+        timeDimensions: [
+            {
+                dimension: 'test_c.time',
+                dateRange: ['2021-01-01', '2021-12-31'],
+                granularity: 'month'
+            }
+        ]
+    };
+    const expectedMembers = [['test_a.country', ['US']], ['test_d.us_segment', null]];
+    assert.deepStrictEqual(extractFiltersMembersWithValues(payload).sort(), expectedMembers.sort());
+});
+
+test('extractFiltersMembersWithValues complex boolean logic', () => {
+    const payload = {
+        segments: [],
+        filters: [
+            {
+                or: [
+                    {
+                        and: [
+                            {
+                                values: ['Corpus Christi'],
+                                member: 'test_a.city',
+                                operator: 'equals'
+                            },
+                            {
+                                member: 'test_b.age_bucket',
+                                operator: 'equals',
+                                values: ['Senior adult']
+                            }
+                        ]
+                    },
+                    {
+                        member: 'test_c.city',
+                        operator: 'equals',
+                        values: ['Sacramento']
+                    }
+                ]
+            },
+            { or: [{ member: 'test_d.city', operator: 'set' }] }
+        ]
+    };
+    const expectedMembers = [
+        ['test_a.city', ['Corpus Christi']],
+        ['test_b.age_bucket', ['Senior adult']],
+        ['test_c.city', ['Sacramento']],
+        ['test_d.city', null]
+    ];
+    assert.deepStrictEqual(extractFiltersMembersWithValues(payload).sort(), expectedMembers.sort());
+});
+
+test('extractFiltersMembersWithValues pushdown filters', () => {
+    const payload = {
+        timezone: 'UTC',
+        timeDimensions: [],
+        filters: [],
+        measures: [
+            {
+                name: 'count_case_when_',
+                expression: [
+                    'internet_sales',
+                    'return `COUNT(CASE WHEN (${internet_sales.salesterritorykey} = 1) THEN 1 END)`'
+                ],
+                definition: '{"cubeName":"internet_sales","alias":"count_case_when_","expr":{"type":"SqlFunction","cubeParams":["internet_sales"],"sql":"COUNT(CASE WHEN (${internet_sales.salesterritorykey} = 1) THEN 1 END)"},"groupingSet":null}',
+                cubeName: 'internet_sales',
+                groupingSet: null,
+                expressionName: 'count_case_when_'
+            }
+        ],
+        order: [],
+        limit: null,
+        segments: [
+            {
+                expression: [
+                    'internet_sales',
+                    'return `CASE WHEN ((${internet_sales.salesterritorykey} = 1) OR (${internet_sales.salesterritorykey} = 9)) THEN TRUE END`'
+                ],
+                groupingSet: null,
+                definition: '{"cubeName":"internet_sales","alias":"case_when_s_sale","expr":{"type":"SqlFunction","cubeParams":["internet_sales"],"sql":"CASE WHEN ((${internet_sales.salesterritorykey} = 1) OR (${internet_sales.salesterritorykey} = 9)) THEN TRUE END"},"groupingSet":null}',
+                cubeName: 'internet_sales',
+                name: 'case_when_s_sale',
+                expressionName: 'case_when_s_sale'
+            }
+        ],
+        dimensions: [
+            {
+                cubeName: 'internet_sales',
+                expressionName: 'productkey',
+                groupingSet: null,
+                name: 'productkey',
+                definition: '{"cubeName":"internet_sales","alias":"productkey","expr":{"type":"SqlFunction","cubeParams":["internet_sales"],"sql":"${internet_sales.productkey}"},"groupingSet":null}',
+                expression: [
+                    'internet_sales',
+                    'return `${internet_sales.productkey}`'
+                ]
+            }
+        ],
+        subqueryJoins: []
+    };
+    const expectedMembers = [['internet_sales.salesterritorykey', [1, 9]]];
+    assert.deepStrictEqual(extractFiltersMembersWithValues(payload).sort(), expectedMembers.sort());
+});
+
+test('extractFiltersMembersWithValues with empty payload', () => {
+    const payload = {};
+    const expectedMembers = [];
+    assert.deepStrictEqual(extractFiltersMembersWithValues(payload), expectedMembers);
+});
+
+test('extractFiltersMembersWithValues with invalid keywords', () => {
+    const payload = { invalid: ['test_a.city', 'test_a.country', 'test_a.state'] };
+    const expectedMembers = [];
+    assert.deepStrictEqual(extractFiltersMembersWithValues(payload), expectedMembers);
+});

--- a/cube-utils-js/test/url-parser.test.js
+++ b/cube-utils-js/test/url-parser.test.js
@@ -1,0 +1,60 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { extractUrlParams } from '../src/url-parser.js';
+
+test('single param', () => {
+    const url = 'https://example.com/?foo=bar';
+    const expected = { foo: 'bar' };
+    assert.deepStrictEqual(extractUrlParams(url), expected);
+});
+
+test('multiple params', () => {
+    const url = 'https://example.com/?foo=bar&baz=qux';
+    const expected = { foo: 'bar', baz: 'qux' };
+    assert.deepStrictEqual(extractUrlParams(url), expected);
+});
+
+test('repeated keys', () => {
+    const url = 'https://example.com/?foo=bar&foo=baz';
+    const expected = { foo: ['bar', 'baz'] };
+    assert.deepStrictEqual(extractUrlParams(url), expected);
+});
+
+test('url encoded value', () => {
+    const url = 'https://example.com/?foo=hello%20world';
+    const expected = { foo: 'hello world' };
+    assert.deepStrictEqual(extractUrlParams(url), expected);
+});
+
+test('empty query', () => {
+    const url = 'https://example.com/';
+    const expected = {};
+    assert.deepStrictEqual(extractUrlParams(url), expected);
+});
+
+test('param with empty value', () => {
+    const url = 'https://example.com/?foo=';
+    const expected = {};
+    assert.deepStrictEqual(extractUrlParams(url), expected);
+});
+
+test('long encoded query param', () => {
+    const url = '/cubejs-api/v1/dry-run?query=%7B%22measures%22%3A%5B%22sales.net_sales_amount%22%5D%2C%22dimensions%22%3A%5B%22sales.currency_code%22%2C%22sales.region%22%2C%22sales.currency_type_code%22%5D%2C%22timeDimensions%22%3A%5B%7B%22dimension%22%3A%22sales.date_financial_ds%22%2C%22dateRange%22%3A%22last+month%22%2C%22granularity%22%3A%22month%22%7D%5D%2C%22filters%22%3A%5B%7B%22values%22%3A%5B%22GBP%22%2C%22USD%22%5D%2C%22member%22%3A%22sales.currency_code%22%2C%22operator%22%3A%22equals%22%7D%5D%7D';
+    const expectedQuery = '{"measures":["sales.net_sales_amount"],"dimensions":["sales.currency_code","sales.region","sales.currency_type_code"],"timeDimensions":[{"dimension":"sales.date_financial_ds","dateRange":"last month","granularity":"month"}],"filters":[{"values":["GBP","USD"],"member":"sales.currency_code","operator":"equals"}]}';
+    const result = extractUrlParams(url);
+    assert.ok('query' in result);
+    assert.strictEqual(result.query, expectedQuery);
+});
+
+test('multiple long encoded urls', () => {
+    const urls = [
+        '/cubejs-api/v1/sql?query=%7B%22measures%22%3A%5B%22sales.net_sales_amount%22%5D%2C%22dimensions%22%3A%5B%22sales.currency_code%22%2C%22sales.region%22%2C%22sales.currency_type_code%22%5D%2C%22timeDimensions%22%3A%5B%7B%22dimension%22%3A%22sales.date_financial_ds%22%2C%22dateRange%22%3A%22last+month%22%2C%22granularity%22%3A%22month%22%7D%5D%2C%22filters%22%3A%5B%7B%22values%22%3A%5B%22GBP%22%2C%22USD%22%5D%2C%22member%22%3A%22sales.currency_code%22%2C%22operator%22%3A%22equals%22%7D%5D%7D',
+        '/cubejs-api/v1/load?query=%7B%22measures%22%3A%5B%22sales.net_sales_amount%22%5D%2C%22dimensions%22%3A%5B%22sales.currency_code%22%2C%22sales.region%22%2C%22sales.currency_type_code%22%5D%2C%22timeDimensions%22%3A%5B%7B%22dimension%22%3A%22sales.date_financial_ds%22%2C%22dateRange%22%3A%22last+month%22%2C%22granularity%22%3A%22month%22%7D%5D%2C%22filters%22%3A%5B%7B%22values%22%3A%5B%22GBP%22%2C%22USD%22%5D%2C%22member%22%3A%22sales.currency_code%22%2C%22operator%22%3A%22equals%22%7D%5D%7D&queryType=multi'
+    ];
+    const expectedQuery = '{"measures":["sales.net_sales_amount"],"dimensions":["sales.currency_code","sales.region","sales.currency_type_code"],"timeDimensions":[{"dimension":"sales.date_financial_ds","dateRange":"last month","granularity":"month"}],"filters":[{"values":["GBP","USD"],"member":"sales.currency_code","operator":"equals"}]}';
+    for (const url of urls) {
+        const result = extractUrlParams(url);
+        assert.ok('query' in result);
+        assert.strictEqual(result.query, expectedQuery);
+    }
+});


### PR DESCRIPTION
- Create cube-utils-js package with identical functionality
- Implement extractCubes, extractMembers, extractFiltersMembers, extractFiltersMembersWithValues
- Add extractUrlParams for URL parameter parsing
- Port all Python tests to JavaScript with 42 passing tests
- Update GitHub Actions to run JS tests and publish to npm
- Update CLAUDE.md documentation for dual-language repository